### PR TITLE
There's no place like JAVA_HOME

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,12 @@ class gvm (
       },
       default => $homedir
     }
+    
+    $home_env = "HOME=$user_home"
+    $base_env = $java_home ? {
+        ''      => [$home_env], 
+        default => [$home_env, "JAVA_HOME=$java_home"]
+    }
 
     wget::fetch {'http://get.gvmtool.net':,
       destination => "/tmp/gvm-install.sh",
@@ -42,7 +48,7 @@ class gvm (
     } ~>
     exec { 'GVM' :
       user        => $owner,
-      environment => ["HOME=$user_home", "JAVA_HOME=$java_home"],
+      environment => $base_env, 
       path        => "/usr/bin:/usr/sbin:/bin",
       command     => "bash gvm-install.sh",
       cwd         => '/tmp',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,7 @@ class gvm (
     $owner = 'root',
     $group = '',
     $homedir = '',
+    $java_home = ''
 ) {
 
     $user_group = $group ? {
@@ -41,7 +42,7 @@ class gvm (
     } ~>
     exec { 'GVM' :
       user        => $owner,
-      environment => "HOME=$user_home",
+      environment => ["HOME=$user_home", "JAVA_HOME=$java_home"],
       path        => "/usr/bin:/usr/sbin:/bin",
       command     => "bash gvm-install.sh",
       cwd         => '/tmp',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -37,7 +37,7 @@ define gvm::package (
   }
 
   exec { "gvm $gvm_operation $package_name $version" :
-    environment => ["HOME=$gvm::user_home", "JAVA_HOME=$gvm::java_home"],
+    environment => $gvm::base_env,
     command      => "bash -c '$gvm_init && gvm $gvm_operation $package_name $version'",
     unless       => $gvm_operation_unless,
     user         => $owner,
@@ -49,7 +49,7 @@ define gvm::package (
   
   if $ensure == present and $is_default {
     exec {"gvm default $package_name $version" :
-      environment => ["HOME=$gvm::user_home", "JAVA_HOME=$gvm::java_home"],
+      environment => $gvm::base_env,
       command     => "bash -c '$gvm_init && gvm default $package_name $version'",
       user        => $owner,
       path        => '/usr/bin:/usr/sbin:/bin',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -37,7 +37,7 @@ define gvm::package (
   }
 
   exec { "gvm $gvm_operation $package_name $version" :
-    environment  => "HOME=$gvm::user_home",
+    environment => ["HOME=$gvm::user_home", "JAVA_HOME=$gvm::java_home"],
     command      => "bash -c '$gvm_init && gvm $gvm_operation $package_name $version'",
     unless       => $gvm_operation_unless,
     user         => $owner,
@@ -49,7 +49,7 @@ define gvm::package (
   
   if $ensure == present and $is_default {
     exec {"gvm default $package_name $version" :
-      environment => "HOME=$gvm::user_home",
+      environment => ["HOME=$gvm::user_home", "JAVA_HOME=$gvm::java_home"],
       command     => "bash -c '$gvm_init && gvm default $package_name $version'",
       user        => $owner,
       path        => '/usr/bin:/usr/sbin:/bin',


### PR DESCRIPTION
Allow passing JAVA_HOME to the GVM module.

I'm very new to Puppet so there could be a different/better way of accomplishing this, but this allowed me to get around the issue.  If I'm understanding the issue, my problem stemmed from the fact that my Puppet manifest was installing Java as part of the initial setup of the VM so the environment didn't have a JAVA_HOME.  This allows to pass that info so it can correctly execute the GVM install and package installations.