### PR TITLE
fix owner variable

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -40,7 +40,7 @@ define gvm::package (
     environment => $gvm::base_env,
     command      => "bash -c '$gvm_init && gvm $gvm_operation $package_name $version'",
     unless       => $gvm_operation_unless,
-    user         => $owner,
+    user         => $gvm::owner,
     require      => Class['gvm'],
     path         => "/usr/bin:/usr/sbin:/bin",
     logoutput    => true,
@@ -51,7 +51,7 @@ define gvm::package (
     exec {"gvm default $package_name $version" :
       environment => $gvm::base_env,
       command     => "bash -c '$gvm_init && gvm default $package_name $version'",
-      user        => $owner,
+      user        => $gvm::owner,
       path        => '/usr/bin:/usr/sbin:/bin',
       logoutput   => true,
       require     => Exec["gvm install $package_name $version"],


### PR DESCRIPTION
It's bad practice to use $owner like that as there is no class inheritance in package.pp.  I strongly recommend using [puppet-lint](http://puppet-lint.com/) to sanity check all puppet modules and manifests.

When using variables defined in other classes you should always use the, sorry I don't know the term, _full??_ name - $other::class::variable, or $class::variable.  The same when using global vars - $::operatingsystem or $::osfamily

This fix makes this work in site.pp

``` puppet
node default {
  class { 'gvm':
    owner => 'ubuntu'
  }
  gvm::package { 'groovy':
    version    => '2.3.1',
    is_default => true,
    ensure     => present
  }
}
```
